### PR TITLE
Add missing install of launch files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ target_link_libraries(${PROJECT_NAME}_node
 ## Install ##
 #############
 
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"


### PR DESCRIPTION
Currently the installation of launch files is missing.
This fixes it.

Check with:
- Clean workspace
- `catkin config --install`
- `catkin b`
- `source install/setup.bash`
- `roslaunch psen_scan psen_scan.launch` <- funktioniert nur mit diesem PR
