### PR TITLE
Fix CodeCoverage inclusion in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,10 +137,9 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
   find_package(roslaunch REQUIRED)
-  find_package(code_coverage REQUIRED)
 
   if(ENABLE_COVERAGE_TESTING)
-    include(CodeCoverage)
+    find_package(code_coverage REQUIRED)
     APPEND_COVERAGE_COMPILER_FLAGS()
   endif()
 


### PR DESCRIPTION
Otherwise on a normal build code_coverage is included and
would throw a warning since the build has no debug flags.

This renders the buildfarm "unstable" see http://build.ros.org/job/Mdev__psen_scan__ubuntu_bionic_amd64/12/

Check the example at https://github.com/mikeferguson/code_coverage.
