### PR TITLE
Adds sleep to udp package availabillity check.

### DIFF
--- a/src/psen_scan_udp_interface.cpp
+++ b/src/psen_scan_udp_interface.cpp
@@ -14,15 +14,17 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "psen_scan/psen_scan_udp_interface.h"
+#include "psen_scan/udp_read_timeout_exception.h"
 #include "psen_scan/scanner_data.h"
 #include <boost/chrono/chrono_io.hpp>
-#include "psen_scan/udp_read_timeout_exception.h"
-
 #include <chrono>
 #include <thread>
 
 namespace psen_scan
 {
+
+static const uint64_t TIMEOUT_LOOP_SLEEP_DURATION_MS_ = 5;
+
 /**
  * @brief Construct a new PSENscanUDPInterface::PSENscanUDPInterface object
  *
@@ -72,7 +74,7 @@ std::size_t PSENscanUDPInterface::read(boost::asio::mutable_buffers_1& buffer)
   Clock::duration d = Clock::now() - t1;
   while (0 == socket_read_.available())
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_LOOP_SLEEP_DURATION_MS_));
     d = Clock::now() - t1;
     Second s(duration_counter);
     if (d > s)

--- a/src/psen_scan_udp_interface.cpp
+++ b/src/psen_scan_udp_interface.cpp
@@ -23,7 +23,7 @@
 namespace psen_scan
 {
 
-static const uint64_t TIMEOUT_LOOP_SLEEP_DURATION_MS_ = 5;
+static const uint64_t TIMEOUT_LOOP_SLEEP_DURATION_MS = 5;
 
 /**
  * @brief Construct a new PSENscanUDPInterface::PSENscanUDPInterface object
@@ -74,7 +74,7 @@ std::size_t PSENscanUDPInterface::read(boost::asio::mutable_buffers_1& buffer)
   Clock::duration d = Clock::now() - t1;
   while (0 == socket_read_.available())
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_LOOP_SLEEP_DURATION_MS_));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_LOOP_SLEEP_DURATION_MS));
     d = Clock::now() - t1;
     Second s(duration_counter);
     if (d > s)

--- a/src/psen_scan_udp_interface.cpp
+++ b/src/psen_scan_udp_interface.cpp
@@ -22,7 +22,6 @@
 
 namespace psen_scan
 {
-
 static const uint64_t TIMEOUT_LOOP_SLEEP_DURATION_MS = 5;
 
 /**

--- a/src/psen_scan_udp_interface.cpp
+++ b/src/psen_scan_udp_interface.cpp
@@ -17,6 +17,10 @@
 #include "psen_scan/scanner_data.h"
 #include <boost/chrono/chrono_io.hpp>
 #include "psen_scan/udp_read_timeout_exception.h"
+
+#include <chrono>
+#include <thread>
+
 namespace psen_scan
 {
 /**
@@ -68,6 +72,7 @@ std::size_t PSENscanUDPInterface::read(boost::asio::mutable_buffers_1& buffer)
   Clock::duration d = Clock::now() - t1;
   while (0 == socket_read_.available())
   {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
     d = Clock::now() - t1;
     Second s(duration_counter);
     if (d > s)


### PR DESCRIPTION
It seems as if the check for udp packages is blocking the cpu due to polling periodically as fast as possible.

Adding a short sleep when no data is available fixes the high cpu issue and should not interfere while fetching data.

Closes #30 